### PR TITLE
Fix proxy cert version logging for POST requests

### DIFF
--- a/api/proxy/server/handlers_cert.go
+++ b/api/proxy/server/handlers_cert.go
@@ -199,6 +199,8 @@ func (svr *Server) handlePostShared(
 	default:
 		return fmt.Errorf("unknown dispersal backend: %v", svr.sm.GetDispersalBackend())
 	}
+	// Set cert version in request context for logging middleware
+	middleware.SetCertVersion(r, string(certVersion))
 	versionedCert := certs.NewVersionedCert(serializedCert, certVersion)
 
 	responseCommit, err := commitments.EncodeCommitment(versionedCert, mode)


### PR DESCRIPTION
This PR fixes the issue where the proxy was logging 'unknown' cert_version when completing HTTP request handlers for POST requests.

## Root Cause
The issue was in the handlePostShared function in api/proxy/server/handlers_cert.go. While the cert version was being determined and logged in the handler itself, it was never being set in the request context for the logging middleware to use.

## The Fix
Added middleware.SetCertVersion(r, string(certVersion)) in handlePostShared function after the cert version is determined but before the versionedCert is created.

## Result
After this fix, POST requests will no longer log cert_version=unknown in the middleware. Instead, they will log the actual cert version, matching the behavior already present in GET requests.

Fixes #1720